### PR TITLE
38215, 35736: Restructuring Node app pipeline + Logging Architecture …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.0.11 (April 2, 2019)
+
+* #38215 - Restructuring/fix Node app pipeline (logging, pm2, swagger)
+* #35736 - Implement Logging Architecture changes for Logging Conditioning Microservices
+
 ## v2.0.10 (March 22, 2019)
 
 * #37763 - Added ODS conditioner processor information to return payload of Country Code Service.

--- a/app/common/dataProvider.js
+++ b/app/common/dataProvider.js
@@ -28,7 +28,6 @@ class DataProvider {
                         throw err;
                     }
                     this.pool = pool;
-                    console.log(`Created database pool...`);
                     return resolve(pool);
                 });
             }
@@ -57,7 +56,6 @@ class DataProvider {
                     return resolve();
                 }
                 this.didShutdown = true;
-                console.log(`Shutting down database connection...`);
                 this.pool.close();
                 this.pool = null;
             }

--- a/app/common/errorResponse.js
+++ b/app/common/errorResponse.js
@@ -1,16 +1,16 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
-class ErrorResponse extends kyber_server_1.BaseProcessor {
-    fx(args) {
+const syber_server_1 = require("syber-server");
+class ErrorResponse extends syber_server_1.BaseProcessor {
+    fx() {
         const result = new Promise((resolve, reject) => {
             try {
                 let message = `Error in Country Code Service`;
                 if (this.executionContext.httpStatus === 404) {
                     message = `Unable to locate path '${this.executionContext.req.path}'`;
                 }
-                if (this.executionContext.raw && typeof this.executionContext.raw === 'string') {
-                    message = this.executionContext.raw;
+                if (this.executionContext.document && typeof this.executionContext.document === 'string') {
+                    message = this.executionContext.document;
                 }
                 return resolve({
                     successful: false,
@@ -22,7 +22,7 @@ class ErrorResponse extends kyber_server_1.BaseProcessor {
                         correlationId: this.executionContext.correlationId,
                         errors: this.executionContext.errors,
                         warnings: this.executionContext.warnings,
-                        comment: args ? args : undefined
+                        comment: this.processorDef.args ? this.processorDef.args : undefined
                     }
                 });
             }
@@ -37,7 +37,7 @@ class ErrorResponse extends kyber_server_1.BaseProcessor {
                         correlationId: this.executionContext.correlationId,
                         errors: this.executionContext.errors,
                         warnings: this.executionContext.warnings,
-                        comment: args ? args : undefined
+                        comment: this.processorDef.args ? this.processorDef.args : undefined
                     }
                 });
             }

--- a/app/common/logger.js
+++ b/app/common/logger.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const winston = require("winston");
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const { combine, timestamp, label, printf } = winston.format;
 const path = require('path');
 const fs = require('fs');
@@ -35,63 +35,61 @@ class Logger {
         this._winstonLogger = winston.createLogger({
             level: 'info',
             format: myFormat,
-            transports: [
-                new winston.transports.File({ filename: this.getDirectory('error'), level: 'error' }),
-                new winston.transports.File({ filename: this.getDirectory('combined') })
-            ]
+            transports: []
         });
-        if (process.env.NODE_ENV !== 'production') {
-            this._winstonLogger.add(new winston.transports.Console({
-                format: consoleFormat
-            }));
-        }
+        this._winstonLogger.add(new winston.transports.Console({
+            format: consoleFormat
+        }));
     }
-    connect(kyber) {
-        kyber.events.on(kyber_server_1.KyberServerEvents.ServerStarted, (args) => {
+    connect(syber) {
+        syber.events.on(syber_server_1.SyberServerEvents.ServerStarted, (args) => {
             this.info(args.correlationId, args, args.source);
         });
-        kyber.events.on(kyber_server_1.KyberServerEvents.ProcessorStarted, (args) => {
-            this.info(args.correlationId, args, args.source);
-        });
-        kyber.events.on(kyber_server_1.KyberServerEvents.ProcessorEnded, (args) => {
-            this.info(args.correlationId, args, args.source);
-        });
-        kyber.events.on(kyber_server_1.KyberServerEvents.ActivityStarted, (args) => {
-            this.info(args.correlationId, args, args.source);
-        });
-        kyber.events.on(kyber_server_1.KyberServerEvents.ActivityEnded, (args) => {
-            this.info(args.correlationId, args, args.source);
-        });
-        kyber.events.on(kyber_server_1.KyberServerEvents.GlobalSchematicError, (args) => {
+        syber.events.on(syber_server_1.SyberServerEvents.GlobalSchematicError, (args) => {
             this.error(args.correlationId, args, args.source);
         });
-        kyber.events.on(kyber_server_1.KyberServerEvents.BeginRequest, (args) => {
+        syber.events.on(syber_server_1.SyberServerEvents.BeginRequest, (args) => {
             this.info(args.correlationId, args, args.source);
         });
-        kyber.events.on(kyber_server_1.KyberServerEvents.RouteHandlerException, (args) => {
+        syber.events.on(syber_server_1.SyberServerEvents.RouteHandlerException, (args) => {
             this.error(args.correlationId, args, args.source);
         });
-        kyber.events.on(kyber_server_1.KyberServerEvents.ExecutionContextAfterLoadParameters, (args) => {
+        syber.events.on(syber_server_1.SyberServerEvents.EndRequest, (args) => {
             this.info(args.correlationId, args, args.source);
         });
-        kyber.events.on(kyber_server_1.KyberServerEvents.EndRequest, (args) => {
-            this.info(args.correlationId, args, args.source);
-        });
-        kyber.events.on(kyber_server_1.KyberServerEvents.ServerStopping, (args) => {
+        syber.events.on(syber_server_1.SyberServerEvents.ServerStopping, (args) => {
             this.info(args.correlationId, args, args.source);
         });
     }
     log(id, message, source) {
-        this._winstonLogger.info(this.logPayload(id, message, source));
+        return new Promise((resolve) => {
+            this._winstonLogger.info(this.logPayload(id, message, source));
+            resolve();
+        });
     }
     info(id, message, source) {
-        this._winstonLogger.info(this.logPayload(id, message, source));
+        return new Promise((resolve) => {
+            this._winstonLogger.info(this.logPayload(id, message, source));
+            resolve();
+        });
     }
     error(id, message, source) {
-        this._winstonLogger.error(this.logPayload(id, message, source));
+        return new Promise((resolve) => {
+            this._winstonLogger.error(this.logPayload(id, message, source));
+            resolve();
+        });
+    }
+    debug(id, message, source) {
+        return new Promise((resolve) => {
+            this._winstonLogger.debug(this.logPayload(id, message, source));
+            resolve();
+        });
     }
     warn(id, message, source) {
-        this._winstonLogger.warn(this.logPayload(id, message, source));
+        return new Promise((resolve) => {
+            this._winstonLogger.warn(this.logPayload(id, message, source));
+            resolve();
+        });
     }
     logPayload(id, message, source) {
         return {

--- a/app/composers/getCountriesComposer.js
+++ b/app/composers/getCountriesComposer.js
@@ -20,11 +20,7 @@ class GetCountriesComposer extends syber_server_1.BaseProcessor {
                 const db = this.executionContext.getSharedResource('dataProvider');
                 const connection = yield db.getConnection();
                 if (!connection) {
-                    return reject({
-                        successful: false,
-                        message: 'Invalid connection',
-                        httpStatus: 500
-                    });
+                    return reject(this.handleError({ message: `Invalid connection` }, `getCountriesComposer.fx`, 500));
                 }
                 let sql = `SELECT ${ORA_COLUMN_LIST} 
                 FROM ${ORA_SHAPE_TABLE_OWNER}.${ORA_SHAPE_TABLE_NAME} W `;
@@ -38,11 +34,7 @@ class GetCountriesComposer extends syber_server_1.BaseProcessor {
                 connection.execute(sql, sqlArgs, (err, oracleResponse) => {
                     connection.close();
                     if (err) {
-                        return reject({
-                            successful: false,
-                            message: `GetCountriesComposer.connection.execute.Error: Oracle Error Number: ${err.errorNum} Offset: ${err.offset}`,
-                            httpStatus: 400
-                        });
+                        return reject(this.handleError(err, `getCountriesComposer.fx`, 400));
                     }
                     oracleResponse.rowCount = oracleResponse.rows.length;
                     oracleResponse.code = 0;
@@ -59,12 +51,7 @@ class GetCountriesComposer extends syber_server_1.BaseProcessor {
                 });
             }
             catch (err) {
-                this.logger.error(this.executionContext.correlationId, `GetCountriesComposer: ${err.message}`, `getCountriesComposer.fx`);
-                return reject({
-                    successful: false,
-                    message: `${err.message}`,
-                    httpStatus: 500
-                });
+                return reject(this.handleError(err, `getCountriesComposer.fx`, 500));
             }
         }));
         return result;

--- a/app/composers/getCountriesComposer.js
+++ b/app/composers/getCountriesComposer.js
@@ -8,10 +8,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const utilities_1 = require("../common/utilities");
-class GetCountriesComposer extends kyber_server_1.BaseProcessor {
-    fx(args) {
+class GetCountriesComposer extends syber_server_1.BaseProcessor {
+    fx() {
         const result = new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
             try {
                 const { ORA_SHAPE_TABLE_NAME, ORA_SHAPE_TABLE_OWNER, ORA_COLUMN_LIST, ORA_SHAPE_COLUMN_NAME, ORA_SHAPE_SRID } = process.env;
@@ -48,8 +48,8 @@ class GetCountriesComposer extends kyber_server_1.BaseProcessor {
                     oracleResponse.code = 0;
                     oracleResponse.message = 'OK';
                     oracleResponse.correlationId = this.executionContext.correlationId;
-                    this.executionContext.raw = Object.assign({}, oracleResponse);
-                    this.executionContext.raw.ODS = utilities_1.Utilities.getOdsProcessorJSON();
+                    this.executionContext.document = Object.assign({}, oracleResponse);
+                    this.executionContext.document.ODS = utilities_1.Utilities.getOdsProcessorJSON();
                     return resolve({
                         successful: true,
                         data: {
@@ -59,10 +59,10 @@ class GetCountriesComposer extends kyber_server_1.BaseProcessor {
                 });
             }
             catch (err) {
-                console.error(`GetCountriesComposer: ${err}`);
+                this.logger.error(this.executionContext.correlationId, `GetCountriesComposer: ${err.message}`, `getCountriesComposer.fx`);
                 return reject({
                     successful: false,
-                    message: `${err}`,
+                    message: `${err.message}`,
                     httpStatus: 500
                 });
             }

--- a/app/composers/healthCheckComposer.js
+++ b/app/composers/healthCheckComposer.js
@@ -8,12 +8,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const utilities_1 = require("../common/utilities");
-class HealthCheckComposer extends kyber_server_1.BaseProcessor {
-    fx(args) {
+class HealthCheckComposer extends syber_server_1.BaseProcessor {
+    fx() {
         const result = new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
-            const { npm_package_version, npm_package_lastupdated } = process.env;
             try {
                 const db = this.executionContext.getSharedResource('dataProvider');
                 const connection = yield db.getConnection();
@@ -32,7 +31,7 @@ class HealthCheckComposer extends kyber_server_1.BaseProcessor {
                             httpStatus: 400
                         });
                     }
-                    this.executionContext.raw = Object.assign({}, {
+                    this.executionContext.document = Object.assign({}, {
                         HealthCheck: `OK`,
                         Message: `Country Code Service is Available`,
                         Database: `Oracle ${connection.oracleServerVersionString}`,
@@ -45,10 +44,10 @@ class HealthCheckComposer extends kyber_server_1.BaseProcessor {
                 });
             }
             catch (err) {
-                console.error(`HealthCheckSchematic: ${err}`);
+                this.logger.error(this.executionContext.correlationId, `HealthCheckSchematic: ${err.message}`, `healthCheckComposer.fx`);
                 return reject({
                     successful: false,
-                    message: `${err}`,
+                    message: `${err.message}`,
                     httpStatus: 500
                 });
             }

--- a/app/composers/healthCheckComposer.js
+++ b/app/composers/healthCheckComposer.js
@@ -17,19 +17,11 @@ class HealthCheckComposer extends syber_server_1.BaseProcessor {
                 const db = this.executionContext.getSharedResource('dataProvider');
                 const connection = yield db.getConnection();
                 if (!connection) {
-                    return reject({
-                        successful: false,
-                        message: 'Invalid connection',
-                        httpStatus: 500
-                    });
+                    return reject(this.handleError({ message: `Invalid Connection` }, `healthCheckComposer.fx`, 500));
                 }
                 connection.ping((err) => {
                     if (err) {
-                        return reject({
-                            successful: false,
-                            message: `HealthCheckComposer.connection.ping.Error: Oracle Error Number: ${err.errorNum} Offset: ${err.offset}`,
-                            httpStatus: 400
-                        });
+                        return reject(this.handleError(err, `healthCheckComposer.fx`, 500));
                     }
                     this.executionContext.document = Object.assign({}, {
                         HealthCheck: `OK`,
@@ -44,12 +36,7 @@ class HealthCheckComposer extends syber_server_1.BaseProcessor {
                 });
             }
             catch (err) {
-                this.logger.error(this.executionContext.correlationId, `HealthCheckSchematic: ${err.message}`, `healthCheckComposer.fx`);
-                return reject({
-                    successful: false,
-                    message: `${err.message}`,
-                    httpStatus: 500
-                });
+                return reject(this.handleError(err, `healthCheckComposer.fx`, 500));
             }
         }));
         return result;

--- a/app/index.js
+++ b/app/index.js
@@ -8,28 +8,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const config = require("config");
 const schematics_1 = require("./schematics");
 const common_1 = require("./common");
-const kyber = new kyber_server_1.KyberServer({
-    port: config.port
+const logger = new common_1.Logger();
+const syber = new syber_server_1.SyberServer({
+    port: config.port,
+    logger: logger
 });
 const dataProvider = new common_1.DataProvider();
-const logger = new common_1.Logger();
-kyber.registerGlobalSchematic(schematics_1.CountryCodeServiceSchematic, [
+syber.registerGlobalSchematic(schematics_1.CountryCodeServiceSchematic, [
     {
         name: 'dataProvider',
         instanceOfType: dataProvider
     }
 ]);
-kyber.events.on(kyber_server_1.KyberServerEvents.ServerStopping, () => {
-    console.log(`\nServer Stopping...`);
+syber.events.on(syber_server_1.SyberServerEvents.ServerStopping, () => {
+    logger.log(`SYS`, `\nServer Stopping...`, `index.onServerStopping`);
     if (dataProvider) {
         dataProvider.shutdown();
     }
 });
-kyber.registerRoute({
+syber.registerRoute({
     verb: 'GET',
     path: '/v2/ods/countrycode/health',
     schematic: schematics_1.HealthCheckGetSchematic,
@@ -40,7 +41,7 @@ kyber.registerRoute({
         }
     ]
 });
-kyber.registerRoute({
+syber.registerRoute({
     verb: 'GET',
     path: '/v2/ods/countrycode/countries',
     schematic: schematics_1.GetCountriesSchematic,
@@ -51,7 +52,7 @@ kyber.registerRoute({
         }
     ]
 });
-kyber.registerRoute({
+syber.registerRoute({
     verb: 'POST',
     path: '/v2/ods/countrycode/countries',
     schematic: schematics_1.PostCountriesSchematic,
@@ -65,22 +66,22 @@ kyber.registerRoute({
 function startup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            console.log(`Initializing Database Provider`);
+            logger.log(`SYS`, `Initializing Database Provider`, `index.startup`);
             yield dataProvider.init();
-            console.log(`Establishing Database Connection`);
+            logger.log(`SYS`, `Establishing Database Connection`, `index.startup`);
             const connection = yield dataProvider.getConnection();
-            console.log(`Testing Ping to Database Connection`);
+            logger.log(`SYS`, `Testing Ping to Database Connection`, `index.startup`);
             yield connection.ping();
-            console.log(`Starting Application Server`);
+            logger.log(`SYS`, `Starting Application Server`, `index.startup`);
             yield connection.close();
-            console.log(`Closed initialization test connection.`);
-            console.log(`Initializing Logging Interface`);
-            logger.connect(kyber);
-            console.log(`Starting up Kyber Server`);
-            kyber.start();
+            logger.log(`SYS`, `Closed initialization test connection.`, `index.startup`);
+            logger.log(`SYS`, `Initializing Logging Interface`, `index.startup`);
+            logger.connect(syber);
+            logger.log(`SYS`, `Starting up Kyber Server`, `index.startup`);
+            syber.start();
         }
         catch (err) {
-            console.error(`ERROR STARTING DATABASE CONNECTION: ${err}`);
+            logger.error(`SYS`, `ERROR STARTING DATABASE CONNECTION: ${err.message}`, `index.startup`);
             process.exit(1);
         }
     });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ods-country-code-lookup",
-  "version": "0.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,12 +24,17 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -353,10 +358,11 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "helmet": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.15.0.tgz",
-      "integrity": "sha512-j9JjtAnWJj09lqe/PEICrhuDaX30TeokXJ9tW6ZPhVH0+LMoihDeJ58CdWeTGzM66p6EiIODmgAaWfdeIWI4Gg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.16.0.tgz",
+      "integrity": "sha512-rsTKRogc5OYGlvSHuq5QsmOsOzF6uDoMqpfh+Np8r23+QxDq+SUx90Rf8HyIKQVl7H6NswZEwfcykinbAeZ6UQ==",
       "requires": {
+        "depd": "2.0.0",
         "dns-prefetch-control": "0.1.0",
         "dont-sniff-mimetype": "1.0.0",
         "expect-ct": "0.1.1",
@@ -366,11 +372,18 @@
         "helmet-csp": "2.7.1",
         "hide-powered-by": "1.0.0",
         "hpkp": "2.0.0",
-        "hsts": "2.1.0",
-        "ienoopen": "1.0.0",
+        "hsts": "2.2.0",
+        "ienoopen": "1.1.0",
         "nocache": "2.0.0",
         "referrer-policy": "1.1.0",
         "x-xss-protection": "1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "helmet-crossdomain": {
@@ -400,9 +413,19 @@
       "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
     },
     "hsts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
-      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
+      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
+      "requires": {
+        "depd": "2.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
     },
     "http-errors": {
       "version": "1.6.3",
@@ -424,9 +447,9 @@
       }
     },
     "ienoopen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.0.0.tgz",
-      "integrity": "sha1-NGpCj0dKrI9QzzeE6i0PFvYr2ms="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
+      "integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ=="
     },
     "inherits": {
       "version": "2.0.3",
@@ -477,38 +500,21 @@
         "colornames": "^1.1.1"
       }
     },
-    "kyber-server": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/kyber-server/-/kyber-server-0.0.12.tgz",
-      "integrity": "sha512-0LVP+J7n/WRuBCmBLONfkyKepG8r7SkifNVmNnC1OWi9obzKPZWHviS1lxVGxvF8aNOmRcllLO+s8TsnIIlvjQ==",
-      "requires": {
-        "body-parser": "^1.18.3",
-        "config": "^2.0.1",
-        "dotenv": "^6.1.0",
-        "express": "^4.16.4",
-        "fs-extra": "^7.0.0",
-        "helmet": "^3.15.0",
-        "lodash": "^4.17.11",
-        "swagger-ui-express": "^4.0.1",
-        "ts-node": "^7.0.1",
-        "uuid": "^3.3.2"
-      }
-    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "logform": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.0.tgz",
-      "integrity": "sha512-srZ6qfWCHLX0HVBuWiBC9CPWh61PFrj/akMSQTEqVOgik8fbpg849VU/kepesr6kBZ42Jsk8Duuabim6hAh27w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
       "requires": {
         "colors": "^1.2.1",
         "fast-safe-stringify": "^2.0.4",
         "fecha": "^2.3.3",
         "ms": "^2.1.1",
-        "triple-beam": "^1.2.0"
+        "triple-beam": "^1.3.0"
       },
       "dependencies": {
         "ms": {
@@ -544,16 +550,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "~1.38.0"
       }
     },
     "minimist": {
@@ -605,9 +611,9 @@
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "oracledb": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-3.1.1.tgz",
-      "integrity": "sha512-NqXMg+5QDdpjA93uQPskVKC4oyXMhBh5Q2THzmEmiZm5ywa5zCUX11ZItZbE4HTXRUXU5M0OX6tO0w3HvyYaEw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-3.1.2.tgz",
+      "integrity": "sha512-DOBKpUlfvGAX6bcpuPGtPVVfOOUqFue8eLjbnnmkDyBTU+YuH+gXHRy4ftlFzkHBXYkrSGenFJrXy8dDfEVXCg=="
     },
     "parseurl": {
       "version": "1.3.2",
@@ -660,9 +666,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-      "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+      "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -741,9 +747,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -768,9 +774,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.20.5.tgz",
-      "integrity": "sha512-DNmJQ1qVkW8xk3wI2VfupOS7IYTHNjYaYX+L4s8B8ksdtoHOx3RsRqJUMIQByojHgb3PwEt+zGdIUwxJ4N5pwg=="
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.0.tgz",
+      "integrity": "sha512-ZFcQoi4XT2t/NGKByVwmb4iERLtGmQQEFqHNC1PmdauWVZ2y80akkzctghgAftTlc8xpUp+I62nm4Km2q82ajQ=="
     },
     "swagger-ui-express": {
       "version": "4.0.2",
@@ -778,6 +784,24 @@
       "integrity": "sha512-XZtXI2+SKT3fgvJSGg4P7Dtmkzr50uoSb09IxbUWmjL538TIGRMZtfdEkjZEEq44xgGNAxMryzBEUdUnkXr8dA==",
       "requires": {
         "swagger-ui-dist": "^3.18.1"
+      }
+    },
+    "syber-server": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/syber-server/-/syber-server-0.1.4.tgz",
+      "integrity": "sha512-me3z00WKKnOvNwATIQAKZtt2Q80K+dECxpwYaEolyTWYaI6taI8FY7crEgFuo/kL9etT2HMnDbCwBlQhMsgkmw==",
+      "requires": {
+        "bluebird": "^3.5.3",
+        "body-parser": "^1.18.3",
+        "config": "^2.0.1",
+        "dotenv": "^6.1.0",
+        "express": "^4.16.4",
+        "fs-extra": "^7.0.0",
+        "helmet": "^3.15.0",
+        "lodash": "^4.17.11",
+        "swagger-ui-express": "^4.0.1",
+        "ts-node": "^7.0.1",
+        "uuid": "^3.3.2"
       }
     },
     "text-hex": {
@@ -845,14 +869,14 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "winston": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.0.tgz",
-      "integrity": "sha512-r2e2ufodByh8U1infSXNLViN7ekqVRoSkcJgpS6AzAyKve0uiUkeQq0kxdSDr8bwaM1rGXprvvoC1B+ocy5L0w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
       "requires": {
         "async": "^2.6.1",
         "diagnostics": "^1.1.1",
         "is-stream": "^1.1.0",
-        "logform": "^2.1.0",
+        "logform": "^2.1.1",
         "one-time": "0.0.4",
         "readable-stream": "^3.1.1",
         "stack-trace": "0.0.x",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ods-country-code-lookup",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -787,9 +787,9 @@
       }
     },
     "syber-server": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/syber-server/-/syber-server-0.1.4.tgz",
-      "integrity": "sha512-me3z00WKKnOvNwATIQAKZtt2Q80K+dECxpwYaEolyTWYaI6taI8FY7crEgFuo/kL9etT2HMnDbCwBlQhMsgkmw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/syber-server/-/syber-server-0.1.7.tgz",
+      "integrity": "sha512-YIAniBuR5WeZ+vjPtpc+Gfkwy2XGrmz7YS4cgLJgMrsZdwLJxSG5dnBeo1y/ZHYJdGse3ia4TZIwruGvv2Xqtw==",
       "requires": {
         "bluebird": "^3.5.3",
         "body-parser": "^1.18.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ods-country-code-lookup",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Lookup any countries whose SHAPE, defined by boundaries, interacts with a provided WKT SHAPE e.g. What countries interact with the WKT shape I provided?",
   "main": "index.js",
   "scripts": {
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thepepto/ods-country-lookup.git"
+    "url": "git+https://github.com/ods-bachmanity/ods-country-code-service"
   },
   "author": "Steven Sederburg <stevenscloud@live.com>",
   "license": "ISC",
   "dependencies": {
     "config": "^2.0.1",
     "dotenv": "^6.1.0",
-    "kyber-server": "0.0.12",
+    "syber-server": "0.1.4",
     "lodash": "^4.17.11",
     "oracledb": "^3.0.0",
     "winston": "^3.1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "config": "^2.0.1",
     "dotenv": "^6.1.0",
-    "syber-server": "0.1.4",
+    "syber-server": "0.1.7",
     "lodash": "^4.17.11",
     "oracledb": "^3.0.0",
     "winston": "^3.1.0"

--- a/app/schemas/defaultResponseSchema.js
+++ b/app/schemas/defaultResponseSchema.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
-class DefaultResponseSchema extends kyber_server_1.SchemaDef {
+const syber_server_1 = require("syber-server");
+class DefaultResponseSchema extends syber_server_1.SchemaDef {
     constructor() {
         super(...arguments);
         this.id = 'DefaultResponseSchema';

--- a/app/schemas/errorResponseSchema.js
+++ b/app/schemas/errorResponseSchema.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
-class ErrorResponseSchema extends kyber_server_1.SchemaDef {
+const syber_server_1 = require("syber-server");
+class ErrorResponseSchema extends syber_server_1.SchemaDef {
     constructor() {
         super(...arguments);
         this.id = 'ErrorResponseSchema';

--- a/app/schemas/healthResponseSchema.js
+++ b/app/schemas/healthResponseSchema.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
-class HealthResponseSchema extends kyber_server_1.SchemaDef {
+const syber_server_1 = require("syber-server");
+class HealthResponseSchema extends syber_server_1.SchemaDef {
     constructor() {
         super(...arguments);
         this.id = 'HealthResponseSchema';

--- a/app/schematics/countryCodeServicesSchematic.js
+++ b/app/schematics/countryCodeServicesSchematic.js
@@ -1,9 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const common_1 = require("../common");
 const schemas_1 = require("../schemas");
-class CountryCodeServiceSchematic extends kyber_server_1.GlobalSchematic {
+class CountryCodeServiceSchematic extends syber_server_1.GlobalSchematic {
     constructor() {
         super(...arguments);
         this.responses = [

--- a/app/schematics/getCountriesSchematic.js
+++ b/app/schematics/getCountriesSchematic.js
@@ -1,10 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const common_1 = require("../common");
 const composers_1 = require("../composers");
 const schemas_1 = require("../schemas");
-class GetCountriesSchematic extends kyber_server_1.Schematic {
+class GetCountriesSchematic extends syber_server_1.Schematic {
     constructor() {
         super(...arguments);
         this.id = 'GetCountriesSchematic';
@@ -18,7 +18,7 @@ class GetCountriesSchematic extends kyber_server_1.Schematic {
                 dataType: 'string',
                 validators: [
                     (value) => {
-                        return kyber_server_1.StartsWithAny(['POINT', 'LINESTRING', 'POLYGON', 'MULTILINESTRING'], value);
+                        return syber_server_1.StartsWithAny(['POINT', 'LINESTRING', 'POLYGON', 'MULTILINESTRING'], value);
                     }
                 ]
             }
@@ -30,7 +30,7 @@ class GetCountriesSchematic extends kyber_server_1.Schematic {
             {
                 id: 'COMPOSE',
                 ordinal: 0,
-                executionMode: kyber_server_1.ExecutionMode.Concurrent,
+                executionMode: syber_server_1.ExecutionMode.Concurrent,
                 description: `Gather a list of countries from the boundaries database.`,
                 processes: [{
                         class: composers_1.GetCountriesComposer,
@@ -42,7 +42,7 @@ class GetCountriesSchematic extends kyber_server_1.Schematic {
         this.responses = [
             {
                 httpStatus: 200,
-                class: kyber_server_1.RawResponse,
+                class: syber_server_1.RawResponse,
                 schema: schemas_1.DefaultResponseSchema
             }
         ];

--- a/app/schematics/healthCheckGetSchematic.js
+++ b/app/schematics/healthCheckGetSchematic.js
@@ -1,10 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const common_1 = require("../common");
 const composers_1 = require("../composers");
 const schemas_1 = require("../schemas");
-class HealthCheckGetSchematic extends kyber_server_1.Schematic {
+class HealthCheckGetSchematic extends syber_server_1.Schematic {
     constructor() {
         super(...arguments);
         this.id = 'HealthCheckSchematic';
@@ -18,7 +18,7 @@ class HealthCheckGetSchematic extends kyber_server_1.Schematic {
             {
                 id: 'COMPOSE',
                 ordinal: 0,
-                executionMode: kyber_server_1.ExecutionMode.Concurrent,
+                executionMode: syber_server_1.ExecutionMode.Concurrent,
                 processes: [{
                         class: composers_1.HealthCheckComposer
                     }],
@@ -28,7 +28,7 @@ class HealthCheckGetSchematic extends kyber_server_1.Schematic {
         this.responses = [
             {
                 httpStatus: 200,
-                class: kyber_server_1.RawResponse,
+                class: syber_server_1.RawResponse,
                 schema: schemas_1.HealthResponseSchema
             }
         ];

--- a/app/schematics/postCountriesSchematic.js
+++ b/app/schematics/postCountriesSchematic.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const kyber_server_1 = require("kyber-server");
+const syber_server_1 = require("syber-server");
 const common_1 = require("../common");
 const composers_1 = require("../composers");
 const _1 = require("./");
@@ -17,7 +17,7 @@ class PostCountriesSchematic extends _1.GetCountriesSchematic {
                 dataType: 'string',
                 validators: [
                     (value) => {
-                        return kyber_server_1.StartsWithAny(['POINT', 'LINESTRING', 'POLYGON', 'MULTILINESTRING'], value);
+                        return syber_server_1.StartsWithAny(['POINT', 'LINESTRING', 'POLYGON', 'MULTILINESTRING'], value);
                     }
                 ]
             }];
@@ -28,7 +28,7 @@ class PostCountriesSchematic extends _1.GetCountriesSchematic {
             {
                 id: 'COMPOSE',
                 ordinal: 0,
-                executionMode: kyber_server_1.ExecutionMode.Concurrent,
+                executionMode: syber_server_1.ExecutionMode.Concurrent,
                 processes: [{
                         class: composers_1.GetCountriesComposer
                     }],
@@ -38,7 +38,7 @@ class PostCountriesSchematic extends _1.GetCountriesSchematic {
         this.responses = [
             {
                 httpStatus: 200,
-                class: kyber_server_1.RawResponse,
+                class: syber_server_1.RawResponse,
                 schema: schemas_1.DefaultResponseSchema
             }
         ];

--- a/common/dataProvider.ts
+++ b/common/dataProvider.ts
@@ -24,7 +24,6 @@ export class DataProvider {
                         throw err
                     }
                     this.pool = pool
-                    console.log(`Created database pool...`)
                     return resolve(pool)
                 })
             }
@@ -62,7 +61,6 @@ export class DataProvider {
                     return resolve()
                 }
                 this.didShutdown = true
-                console.log(`Shutting down database connection...`)
                 this.pool.close()
                 this.pool = null
             }

--- a/common/errorResponse.ts
+++ b/common/errorResponse.ts
@@ -1,17 +1,17 @@
-import { BaseProcessor, ProcessorResponse } from 'kyber-server'
+import { BaseProcessor, ProcessorResponse, ProcessorErrorResponse } from 'syber-server'
 
 export class ErrorResponse extends BaseProcessor {
     
-    fx(args: any): Promise<ProcessorResponse> {
+    fx(): Promise<ProcessorResponse|ProcessorErrorResponse> {
 
-        const result: Promise<ProcessorResponse> = new Promise((resolve, reject) => {
+        const result: Promise<ProcessorResponse|ProcessorErrorResponse> = new Promise((resolve, reject) => {
             try {
                 let message = `Error in Country Code Service`
                 if (this.executionContext.httpStatus === 404) {
                     message = `Unable to locate path '${this.executionContext.req.path}'`
                 }
-                if (this.executionContext.raw && typeof this.executionContext.raw === 'string') {
-                    message = this.executionContext.raw
+                if (this.executionContext.document && typeof this.executionContext.document === 'string') {
+                    message = this.executionContext.document
                 }
                 
                 return resolve({
@@ -24,7 +24,7 @@ export class ErrorResponse extends BaseProcessor {
                         correlationId: this.executionContext.correlationId,
                         errors: this.executionContext.errors,
                         warnings: this.executionContext.warnings,
-                        comment: args ? args : undefined // using undefined will prevent the element from being included if args is null
+                        comment: this.processorDef.args ? this.processorDef.args : undefined // using undefined will prevent the element from being included if args is null
                     }
                 })
             }
@@ -39,7 +39,7 @@ export class ErrorResponse extends BaseProcessor {
                         correlationId: this.executionContext.correlationId,
                         errors: this.executionContext.errors,
                         warnings: this.executionContext.warnings,
-                        comment: args ? args : undefined
+                        comment: this.processorDef.args ? this.processorDef.args : undefined
                     }
                 })
             }

--- a/common/logger.ts
+++ b/common/logger.ts
@@ -1,5 +1,5 @@
 import * as winston from 'winston'
-import { KyberServer, KyberServerEvents } from 'kyber-server'
+import { SyberServer, SyberServerEvents, ILogger } from 'syber-server'
 const { combine, timestamp, label, printf } = winston.format
 const path = require('path')
 const fs = require('fs')
@@ -33,90 +33,113 @@ const consoleFormat = printf(info => {
     })
 })
 
-export class Logger {
+export class Logger implements ILogger {
 
     private _winstonLogger?: winston.Logger = null
     constructor() {
 
+        // this._winstonLogger = winston.createLogger({
+        //     level: 'info',
+        //     format: myFormat,
+        //     transports: [
+        //       new winston.transports.File({ filename: this.getDirectory('error'), level: 'error' }),
+        //       new winston.transports.File({ filename: this.getDirectory('combined') })
+        //     ]
+        // })
         this._winstonLogger = winston.createLogger({
             level: 'info',
             format: myFormat,
-            transports: [
-              new winston.transports.File({ filename: this.getDirectory('error'), level: 'error' }),
-              new winston.transports.File({ filename: this.getDirectory('combined') })
-            ]
+            transports: []
         })
         //
         // If we're not in production then log to the `console` with the format:
         // `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
         // 
-        if (process.env.NODE_ENV !== 'production') {
-            this._winstonLogger.add(new winston.transports.Console({
-                format: consoleFormat
-            }))
-        }
+        // if (process.env.NODE_ENV !== 'production') {
+        // }
+        this._winstonLogger.add(new winston.transports.Console({
+            format: consoleFormat
+        }))
     }
 
-    public connect(kyber: KyberServer) {
+    public connect(syber: SyberServer) {
 
         // #region Event Handlers
-        kyber.events.on(KyberServerEvents.ServerStarted, (args) => {
+        syber.events.on(SyberServerEvents.ServerStarted, (args) => {
             this.info(args.correlationId, args, args.source)
         })
 
-        kyber.events.on(KyberServerEvents.ProcessorStarted, (args) => {
-            this.info(args.correlationId, args, args.source)
-        })
+        // syber.events.on(SyberServerEvents.ProcessorStarted, (args) => {
+        //     this.info(args.correlationId, args, args.source)
+        // })
 
-        kyber.events.on(KyberServerEvents.ProcessorEnded, (args) => {
-            this.info(args.correlationId, args, args.source)
-        })
+        // syber.events.on(SyberServerEvents.ProcessorEnded, (args) => {
+        //     this.info(args.correlationId, args, args.source)
+        // })
 
-        kyber.events.on(KyberServerEvents.ActivityStarted, (args) => {
-            this.info(args.correlationId, args, args.source)
-        })
+        // syber.events.on(SyberServerEvents.ActivityStarted, (args) => {
+        //     this.info(args.correlationId, args, args.source)
+        // })
 
-        kyber.events.on(KyberServerEvents.ActivityEnded, (args) => {
-            this.info(args.correlationId, args, args.source)
-        })
+        // syber.events.on(SyberServerEvents.ActivityEnded, (args) => {
+        //     this.info(args.correlationId, args, args.source)
+        // })
 
-        kyber.events.on(KyberServerEvents.GlobalSchematicError, (args) => {
+        syber.events.on(SyberServerEvents.GlobalSchematicError, (args) => {
             this.error(args.correlationId, args, args.source)
         })
 
-        kyber.events.on(KyberServerEvents.BeginRequest, (args) => {
+        syber.events.on(SyberServerEvents.BeginRequest, (args) => {
             this.info(args.correlationId, args, args.source)
         })
 
-        kyber.events.on(KyberServerEvents.RouteHandlerException, (args) => {
+        syber.events.on(SyberServerEvents.RouteHandlerException, (args) => {
             this.error(args.correlationId, args, args.source)
         })
 
-        kyber.events.on(KyberServerEvents.ExecutionContextAfterLoadParameters, (args) => {
+        // syber.events.on(SyberServerEvents.ExecutionContextAfterLoadParameters, (args) => {
+        //     this.info(args.correlationId, args, args.source)
+        // })
+
+        syber.events.on(SyberServerEvents.EndRequest, (args) => {
             this.info(args.correlationId, args, args.source)
         })
 
-        kyber.events.on(KyberServerEvents.EndRequest, (args) => {
-            this.info(args.correlationId, args, args.source)
-        })
-
-        kyber.events.on(KyberServerEvents.ServerStopping, (args) => {
+        syber.events.on(SyberServerEvents.ServerStopping, (args) => {
             this.info(args.correlationId, args, args.source)
         })
         // #endregion
     }
 
-    public log(id: string, message: string, source: string) {
-        this._winstonLogger.info(this.logPayload(id, message, source))
+    public log(id: string, message: string, source: string): Promise<any> {
+        return new Promise((resolve) => {
+            this._winstonLogger.info(this.logPayload(id, message, source))
+            resolve()
+        })
     }
-    public info(id: string, message: string, source: string) {
-        this._winstonLogger.info(this.logPayload(id, message, source))
+    public info(id: string, message: string, source: string): Promise<any> {
+        return new Promise((resolve) => {
+            this._winstonLogger.info(this.logPayload(id, message, source))
+            resolve()
+        })
     }
-    public error(id: string, message: string, source: string) {
-        this._winstonLogger.error(this.logPayload(id, message, source))
+    public error(id: string, message: string, source: string): Promise<any> {
+        return new Promise((resolve) => {
+            this._winstonLogger.error(this.logPayload(id, message, source))
+            resolve()
+        })
     }
-    public warn(id: string, message: string, source: string) {
-        this._winstonLogger.warn(this.logPayload(id, message, source))
+    public debug(id: string, message: string, source: string): Promise<any> {
+        return new Promise((resolve) => {
+            this._winstonLogger.debug(this.logPayload(id, message, source))
+            resolve()
+        })
+    }
+    public warn(id: string, message: string, source: string): Promise<any> {
+        return new Promise((resolve) => {
+            this._winstonLogger.warn(this.logPayload(id, message, source))
+            resolve()
+        })
     }
 
     private logPayload(id: string, message: string, source: string): any {

--- a/composers/getCountriesComposer.ts
+++ b/composers/getCountriesComposer.ts
@@ -1,9 +1,9 @@
-import { BaseProcessor, ProcessorResponse } from 'kyber-server'
+import { BaseProcessor, ProcessorResponse } from 'syber-server'
 import { Utilities } from '../common/utilities';
 
 export class GetCountriesComposer extends BaseProcessor {
 
-    public fx(args: any): Promise<ProcessorResponse> {
+    public fx(): Promise<ProcessorResponse> {
         
         const result: Promise<ProcessorResponse> = new Promise(async(resolve, reject) => {
             
@@ -47,8 +47,8 @@ export class GetCountriesComposer extends BaseProcessor {
                         oracleResponse.message = 'OK'
                         oracleResponse.correlationId = this.executionContext.correlationId
                         
-                        this.executionContext.raw = Object.assign({}, oracleResponse)
-                        this.executionContext.raw.ODS =  Utilities.getOdsProcessorJSON();
+                        this.executionContext.document = Object.assign({}, oracleResponse)
+                        this.executionContext.document.ODS =  Utilities.getOdsProcessorJSON();
                         return resolve({
                             successful: true,
                             data: {
@@ -58,10 +58,10 @@ export class GetCountriesComposer extends BaseProcessor {
                 })
             }
             catch (err) {
-                console.error(`GetCountriesComposer: ${err}`)
+                this.logger.error(this.executionContext.correlationId, `GetCountriesComposer: ${err.message}`, `getCountriesComposer.fx`)
                 return reject({
                     successful: false,
-                    message: `${err}`,
+                    message: `${err.message}`,
                     httpStatus: 500
                 })
             }

--- a/composers/healthCheckComposer.ts
+++ b/composers/healthCheckComposer.ts
@@ -1,13 +1,12 @@
-import { BaseProcessor, ProcessorResponse } from 'kyber-server';
+import { BaseProcessor, ProcessorResponse } from 'syber-server';
 import { Utilities } from '../common/utilities';
 
 export class HealthCheckComposer extends BaseProcessor {
 
-    public fx(args: any): Promise<ProcessorResponse> {
+    public fx(): Promise<ProcessorResponse> {
         
         const result: Promise<ProcessorResponse> = new Promise(async(resolve, reject) => {
             
-            const { npm_package_version, npm_package_lastupdated } = process.env;
             try {
                 const db = this.executionContext.getSharedResource('dataProvider')
                 const connection = await db.getConnection()
@@ -27,7 +26,7 @@ export class HealthCheckComposer extends BaseProcessor {
                         })
                     }
 
-                    this.executionContext.raw = Object.assign({}, {
+                    this.executionContext.document = Object.assign({}, {
                         HealthCheck: `OK`,
                         Message: `Country Code Service is Available`,
                         Database: `Oracle ${connection.oracleServerVersionString}`,
@@ -41,10 +40,10 @@ export class HealthCheckComposer extends BaseProcessor {
 
             }
             catch (err) {
-                console.error(`HealthCheckSchematic: ${err}`)
+                this.logger.error(this.executionContext.correlationId, `HealthCheckSchematic: ${err.message}`, `healthCheckComposer.fx`)
                 return reject({
                     successful: false,
-                    message: `${err}`,
+                    message: `${err.message}`,
                     httpStatus: 500
                 })
             }

--- a/index.ts
+++ b/index.ts
@@ -1,19 +1,21 @@
-import {KyberServer, KyberServerEvents } from 'kyber-server'
+import {SyberServer, SyberServerEvents } from 'syber-server'
 import * as config from 'config'
 import { HealthCheckGetSchematic, GetCountriesSchematic, PostCountriesSchematic, CountryCodeServiceSchematic } from './schematics'
 import { DataProvider, Logger } from './common'
 
+const logger = new Logger()
+
 // Stand up Express Server Common Framework
-const kyber = new KyberServer({
-    port: config.port
+const syber = new SyberServer({
+    port: config.port,
+    logger: logger
 })
 
 // declare an instance of the oracle database to be shared with schematics
 const dataProvider = new DataProvider()
-const logger = new Logger()
 
 // register a global schematic to handle errors, run before each execution, run after each execution, startup and shutdown
-kyber.registerGlobalSchematic(
+syber.registerGlobalSchematic(
     CountryCodeServiceSchematic,
     [
         {
@@ -24,15 +26,15 @@ kyber.registerGlobalSchematic(
 )
 
 // Handle Shutdown Event gracefully. Close database connection
-kyber.events.on(KyberServerEvents.ServerStopping, () => {
-    console.log(`\nServer Stopping...`)
+syber.events.on(SyberServerEvents.ServerStopping, () => {
+    logger.log(`SYS`, `\nServer Stopping...`, `index.onServerStopping`)
     if (dataProvider) {
         dataProvider.shutdown()
     }
 })
     
 // GET /v2/ods/countrycode/health
-kyber.registerRoute({
+syber.registerRoute({
     verb: 'GET',
     path: '/v2/ods/countrycode/health',
     schematic: HealthCheckGetSchematic,
@@ -45,7 +47,7 @@ kyber.registerRoute({
 })
 
 // GET /v2/ods/countrycode/countries
-kyber.registerRoute({
+syber.registerRoute({
     verb: 'GET',
     path: '/v2/ods/countrycode/countries',
     schematic: GetCountriesSchematic,
@@ -58,7 +60,7 @@ kyber.registerRoute({
 })
 
 // POST /v2/ods/countrycode/countries
-kyber.registerRoute({
+syber.registerRoute({
     verb: 'POST',
     path: '/v2/ods/countrycode/countries',
     schematic: PostCountriesSchematic,
@@ -74,22 +76,22 @@ kyber.registerRoute({
 // Note: We do not call kyber.start() until after all routes are registered and all shared resources are verified/seeded etc.
 async function startup() {
     try {
-        console.log(`Initializing Database Provider`)
+        logger.log(`SYS`, `Initializing Database Provider`, `index.startup`)
         await dataProvider.init()
-        console.log(`Establishing Database Connection`)
+        logger.log(`SYS`, `Establishing Database Connection`, `index.startup`)
         const connection = await dataProvider.getConnection()
-        console.log(`Testing Ping to Database Connection`)
+        logger.log(`SYS`, `Testing Ping to Database Connection`, `index.startup`)
         await connection.ping()
-        console.log(`Starting Application Server`)
+        logger.log(`SYS`, `Starting Application Server`, `index.startup`)
         await connection.close()
-        console.log(`Closed initialization test connection.`)
-        console.log(`Initializing Logging Interface`)
-        logger.connect(kyber)
-        console.log(`Starting up Kyber Server`)
-        kyber.start()
+        logger.log(`SYS`, `Closed initialization test connection.`, `index.startup`)
+        logger.log(`SYS`, `Initializing Logging Interface`, `index.startup`)
+        logger.connect(syber)
+        logger.log(`SYS`, `Starting up Kyber Server`, `index.startup`)
+        syber.start()
     }
     catch (err) {
-        console.error(`ERROR STARTING DATABASE CONNECTION: ${err}`)
+        logger.error(`SYS`, `ERROR STARTING DATABASE CONNECTION: ${err.message}`, `index.startup`)
         process.exit(1)
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3837,9 +3837,9 @@
       }
     },
     "syber-server": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/syber-server/-/syber-server-0.1.4.tgz",
-      "integrity": "sha512-me3z00WKKnOvNwATIQAKZtt2Q80K+dECxpwYaEolyTWYaI6taI8FY7crEgFuo/kL9etT2HMnDbCwBlQhMsgkmw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/syber-server/-/syber-server-0.1.7.tgz",
+      "integrity": "sha512-YIAniBuR5WeZ+vjPtpc+Gfkwy2XGrmz7YS4cgLJgMrsZdwLJxSG5dnBeo1y/ZHYJdGse3ia4TZIwruGvv2Xqtw==",
       "requires": {
         "bluebird": "^3.5.3",
         "body-parser": "^1.18.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ods-country-code-lookup",
-  "version": "0.0.9",
+  "version": "2.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1943,10 +1943,11 @@
       }
     },
     "helmet": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.15.0.tgz",
-      "integrity": "sha512-j9JjtAnWJj09lqe/PEICrhuDaX30TeokXJ9tW6ZPhVH0+LMoihDeJ58CdWeTGzM66p6EiIODmgAaWfdeIWI4Gg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.16.0.tgz",
+      "integrity": "sha512-rsTKRogc5OYGlvSHuq5QsmOsOzF6uDoMqpfh+Np8r23+QxDq+SUx90Rf8HyIKQVl7H6NswZEwfcykinbAeZ6UQ==",
       "requires": {
+        "depd": "2.0.0",
         "dns-prefetch-control": "0.1.0",
         "dont-sniff-mimetype": "1.0.0",
         "expect-ct": "0.1.1",
@@ -1956,11 +1957,18 @@
         "helmet-csp": "2.7.1",
         "hide-powered-by": "1.0.0",
         "hpkp": "2.0.0",
-        "hsts": "2.1.0",
-        "ienoopen": "1.0.0",
+        "hsts": "2.2.0",
+        "ienoopen": "1.1.0",
         "nocache": "2.0.0",
         "referrer-policy": "1.1.0",
         "x-xss-protection": "1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "helmet-crossdomain": {
@@ -1990,9 +1998,19 @@
       "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
     },
     "hsts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
-      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
+      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
+      "requires": {
+        "depd": "2.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -2061,9 +2079,9 @@
       }
     },
     "ienoopen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.0.0.tgz",
-      "integrity": "sha1-NGpCj0dKrI9QzzeE6i0PFvYr2ms="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
+      "integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ=="
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -2446,23 +2464,6 @@
       "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
       "requires": {
         "colornames": "^1.1.1"
-      }
-    },
-    "kyber-server": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/kyber-server/-/kyber-server-0.0.12.tgz",
-      "integrity": "sha512-0LVP+J7n/WRuBCmBLONfkyKepG8r7SkifNVmNnC1OWi9obzKPZWHviS1lxVGxvF8aNOmRcllLO+s8TsnIIlvjQ==",
-      "requires": {
-        "body-parser": "^1.18.3",
-        "config": "^2.0.1",
-        "dotenv": "^6.1.0",
-        "express": "^4.16.4",
-        "fs-extra": "^7.0.0",
-        "helmet": "^3.15.0",
-        "lodash": "^4.17.11",
-        "swagger-ui-express": "^4.0.1",
-        "ts-node": "^7.0.1",
-        "uuid": "^3.3.2"
       }
     },
     "latest-version": {
@@ -3823,9 +3824,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.20.5.tgz",
-      "integrity": "sha512-DNmJQ1qVkW8xk3wI2VfupOS7IYTHNjYaYX+L4s8B8ksdtoHOx3RsRqJUMIQByojHgb3PwEt+zGdIUwxJ4N5pwg=="
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.0.tgz",
+      "integrity": "sha512-ZFcQoi4XT2t/NGKByVwmb4iERLtGmQQEFqHNC1PmdauWVZ2y80akkzctghgAftTlc8xpUp+I62nm4Km2q82ajQ=="
     },
     "swagger-ui-express": {
       "version": "4.0.2",
@@ -3833,6 +3834,31 @@
       "integrity": "sha512-XZtXI2+SKT3fgvJSGg4P7Dtmkzr50uoSb09IxbUWmjL538TIGRMZtfdEkjZEEq44xgGNAxMryzBEUdUnkXr8dA==",
       "requires": {
         "swagger-ui-dist": "^3.18.1"
+      }
+    },
+    "syber-server": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/syber-server/-/syber-server-0.1.4.tgz",
+      "integrity": "sha512-me3z00WKKnOvNwATIQAKZtt2Q80K+dECxpwYaEolyTWYaI6taI8FY7crEgFuo/kL9etT2HMnDbCwBlQhMsgkmw==",
+      "requires": {
+        "bluebird": "^3.5.3",
+        "body-parser": "^1.18.3",
+        "config": "^2.0.1",
+        "dotenv": "^6.1.0",
+        "express": "^4.16.4",
+        "fs-extra": "^7.0.0",
+        "helmet": "^3.15.0",
+        "lodash": "^4.17.11",
+        "swagger-ui-express": "^4.0.1",
+        "ts-node": "^7.0.1",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+        }
       }
     },
     "symbol": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ods-country-code-lookup",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Lookup any countries whose SHAPE, defined by boundaries, interacts with a provided WKT SHAPE e.g. What countries interact with the WKT shape I provided?",
   "main": "index.ts",
   "scripts": {
@@ -14,16 +14,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thepepto/ods-country-lookup.git"
+    "url": "git+https://github.com/ods-bachmanity/ods-country-code-service"
   },
   "author": "Steven Sederburg <stevenscloud@live.com>",
   "license": "ISC",
   "dependencies": {
     "config": "^2.0.1",
     "dotenv": "^6.1.0",
-    "kyber-server": "0.0.12",
     "lodash": "^4.17.11",
     "oracledb": "^3.0.0",
+    "syber-server": "0.1.4",
     "ts-node": "^7.0.1",
     "winston": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^6.1.0",
     "lodash": "^4.17.11",
     "oracledb": "^3.0.0",
-    "syber-server": "0.1.4",
+    "syber-server": "0.1.7",
     "ts-node": "^7.0.1",
     "winston": "^3.1.0"
   },

--- a/schemas/defaultResponseSchema.ts
+++ b/schemas/defaultResponseSchema.ts
@@ -1,4 +1,4 @@
-import { SchemaDef } from 'kyber-server'
+import { SchemaDef } from 'syber-server'
 
 export class DefaultResponseSchema extends SchemaDef {
     id = 'DefaultResponseSchema'

--- a/schemas/errorResponseSchema.ts
+++ b/schemas/errorResponseSchema.ts
@@ -1,4 +1,4 @@
-import { SchemaDef } from 'kyber-server'
+import { SchemaDef } from 'syber-server'
 
 export class ErrorResponseSchema extends SchemaDef {
     id = 'ErrorResponseSchema'

--- a/schemas/healthResponseSchema.ts
+++ b/schemas/healthResponseSchema.ts
@@ -1,4 +1,4 @@
-import { SchemaDef } from 'kyber-server'
+import { SchemaDef } from 'syber-server'
 
 export class HealthResponseSchema extends SchemaDef {
     id = 'HealthResponseSchema'

--- a/schematics/countryCodeServicesSchematic.ts
+++ b/schematics/countryCodeServicesSchematic.ts
@@ -1,4 +1,4 @@
-import { GlobalSchematic, SchematicResponse } from 'kyber-server'
+import { GlobalSchematic, SchematicResponse } from 'syber-server'
 import { ErrorResponse } from '../common'
 import { ErrorResponseSchema } from '../schemas'
 

--- a/schematics/getCountriesSchematic.ts
+++ b/schematics/getCountriesSchematic.ts
@@ -1,5 +1,5 @@
 import { Schematic, Parameter, Activity, StartsWithAny, ExecutionMode,
-    SchematicResponse, RawResponse } from 'kyber-server'
+    SchematicResponse, RawResponse } from 'syber-server'
 import { DataProvider, ErrorResponse } from '../common'
 import { GetCountriesComposer } from '../composers'
 import { DefaultResponseSchema, ErrorResponseSchema } from '../schemas'

--- a/schematics/healthCheckGetSchematic.ts
+++ b/schematics/healthCheckGetSchematic.ts
@@ -1,4 +1,4 @@
-import { Schematic, Parameter, Activity, ExecutionMode, SchematicResponse, RawResponse } from 'kyber-server'
+import { Schematic, Parameter, Activity, ExecutionMode, SchematicResponse, RawResponse } from 'syber-server'
 import { DataProvider, ErrorResponse } from '../common'
 import { HealthCheckComposer } from '../composers'
 import { HealthResponseSchema } from '../schemas'

--- a/schematics/postCountriesSchematic.ts
+++ b/schematics/postCountriesSchematic.ts
@@ -1,4 +1,4 @@
-import { Schematic, Parameter, Activity, ExecutionMode, StartsWithAny, SchematicResponse, RawResponse } from 'kyber-server'
+import { Schematic, Parameter, Activity, ExecutionMode, StartsWithAny, SchematicResponse, RawResponse } from 'syber-server'
 import { DataProvider, ErrorResponse } from '../common'
 import { GetCountriesComposer } from '../composers'
 import { GetCountriesSchematic } from './'


### PR DESCRIPTION
- New syber-server (0.1.7) includes changes to executionContext.raw NOW executionContext.document
- Logger implementation sent to syber-server ctor for use instead of console.*
- Logging implementation uses async promises to not block main thread
- Removed logging of all execution events. Now only logging Begin and End Request alongside any application errors.
- syber-server now uses bluebird promises to support async activities vs. sequential activities
- No more usage of console.* in CCS
- Common interface syber-server.ILogger allows integration with any class implementing the interface
- Request object exposed on executionContext.req. Available for reference from any processor
- Express Application now available as SyberServer.express after syber-server is instantiated
- Removed args optional argument from fx method in BaseProcessor. Now all fx methods can be called as fx() without any arguments. Arguments are pulled from the ProcessorDefinition which is sent to the ctor of the processor at runtime. Devs can reference args from the schematic using the syntax `const myValue = this.processorDef.args.someValue`
- Similar to what was done in GCS, removed file output of logs. Now logs are only written by PM2 into appropriate directory defined in ecosystem.config.json document for PM2 startup config
- Ctor of BaseProcessor now includes parameter for ILogger to support deeply nested processors e.g. one processor calls another which calls another.

Core functionality of engine remains unchanged.